### PR TITLE
fix: preserve duplicate queries in batch export (fixes #5)

### DIFF
--- a/apiModels/workflow/make_workflow.py
+++ b/apiModels/workflow/make_workflow.py
@@ -136,7 +136,8 @@ class WorkflowBuilder:
             output_file.parent.mkdir(parents=True, exist_ok=True)
             
             with open(output_file, 'w', encoding='utf-8') as f:
-                for query, fetcher_results in results.items():
+                for query in queries:
+                    fetcher_results = results.get(query, {})
                     f.write(f"% Query: {query}\n")
                     if not fetcher_results:
                         f.write("% No citations found\n\n")
@@ -148,7 +149,7 @@ class WorkflowBuilder:
 
             # Log statistics
             total = len(queries)
-            found = sum(1 for r in results.values() if r)
+            found = sum(1 for query in queries if results.get(query))
             self.logger.info(f"Processed {total} queries, found {found} citations")
             
             return True

--- a/test/test_api_models.py
+++ b/test/test_api_models.py
@@ -2,6 +2,7 @@ from unittest.mock import MagicMock
 
 import pytest
 from apiModels import (
+    BibTexFetcher,
     CrossRefBibTeX,
     DBLPBibTeX,
     GoogleScholarBibTeX,
@@ -202,6 +203,32 @@ class TestWorkflowBuilder:
         assert output_file.exists()
         content = output_file.read_text(encoding='utf-8')
         assert '@' in content
+
+    def test_process_file_preserves_duplicate_queries(self, tmp_path):
+        class DummyFetcher(BibTexFetcher):
+            def get_bibtex(self, query):
+                return f"@article{{{query.replace(' ', '_')}}}"
+
+            def get_multiple_bibtex(self, queries):
+                return {query: self.get_bibtex(query) for query in queries}
+
+        workflow = WorkflowBuilder()
+        workflow.add_fetcher(DummyFetcher())
+
+        duplicate_query = "Repeated Paper"
+        input_file = tmp_path / "duplicate_input.txt"
+        input_file.write_text(
+            f"{duplicate_query}\n{duplicate_query}\n",
+            encoding='utf-8'
+        )
+        output_file = tmp_path / "duplicate_output.bib"
+
+        success = workflow.process_file(str(input_file), str(output_file))
+
+        assert success
+        content = output_file.read_text(encoding='utf-8')
+        assert content.count(f"% Query: {duplicate_query}") == 2
+        assert content.count("% Source: DummyFetcher") == 2
 
     def test_get_statistics(self, workflow):
         stats = workflow.get_statistics()


### PR DESCRIPTION
## Problem
- `WorkflowBuilder.process_file()` writes batch results by iterating the deduplicated `results` map.
- When the input file contains the same query more than once, only one output block is written, so later duplicate lines disappear from the exported `.bib` file.

## Fix
- Iterate over the original `queries` list when writing output so repeated input lines are preserved in order.
- Count `found` results against the original query list for consistent batch statistics.
- Add a regression test covering duplicate queries in a batch input file.

## Validation
- `PYTHONPATH=. uv run --with requests --with tqdm --with pytest --with google-search-results pytest test/test_api_models.py -q -k 'preserves_duplicate_queries or test_process_file'`

Fixes #5